### PR TITLE
Set chmod to files AND directories

### DIFF
--- a/src/main/java/org/codehaus/plexus/archiver/dir/DirectoryArchiver.java
+++ b/src/main/java/org/codehaus/plexus/archiver/dir/DirectoryArchiver.java
@@ -168,7 +168,7 @@ public class DirectoryArchiver
 	    {
 		// compute relative path
 		String relative = outFile.getAbsolutePath().replaceFirst(getDestFile().getAbsolutePath(), ".");
-		getLogger().info( "Set chmod " + Integer.toOctalString( 0x0fff & entry.getMode() ) + " for " + relative );
+		getLogger().info( "Set chmod " + Integer.toString( UnixStat.PERM_MASK & entry.getMode() ) + " for " + relative );
 		// call chmod (java or system)		
 		ArchiveEntryUtils.chmod( outFile, entry.getMode(), getLogger(), isUseJvmChmod() );
 	    }


### PR DESCRIPTION
I've noticed an old bug with plexus-archiver (via maven-assembly-plugin).

There are no permission set on folders for assembly of type `dir` (class `DirectoryArchiver`).

Despite having set the `directoryMode`, the permissions are ignored and the folder have default rights (those from umask, usually 755).

This patch set permission to any file (and directory).

Similar bugs found :
- https://issues.apache.org/jira/browse/MASSEMBLY-621
- http://w3facility.org/question/how-do-i-set-directory-permissions-in-maven-output/
